### PR TITLE
Workflow Etapa 3 #3

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -26,6 +26,7 @@ jobs:
       - name: Test
         run: npm test
   
+
   build:
     runs-on: ubuntu-latest
 
@@ -48,7 +49,8 @@ jobs:
           name: github-pages
           path: dist/
           retention-days: 0
-        
+
+
   deploy:
     runs-on: ubuntu-latest
 
@@ -67,3 +69,65 @@ jobs:
       - name: Deploy para o GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+
+  build-android:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Node.js @20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Dependencies
+        run: npm ci
+
+      - name: JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Montar .env
+        run: echo "EXPO_PUBLIC_TMDB_API_KEY=${{ secrets.TMDB_API_KEY }}" > .env
+
+      - name: Prebuild Android
+        run: npx expo prebuild --platform android --no-install
+
+      - name: Permissão gradlew
+        run: chmod +x android/gradlew
+
+      - name: Compilar APK
+        run: cd android && ./gradlew assembleRelease
+
+      - name: Upload APK como artefato
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-release
+          path: android/app/build/outputs/apk/release/app-release.apk
+
+
+  create-release:
+      runs-on: ubuntu-latest
+      needs: build-android
+      permissions:
+        contents: write
+      steps:
+        - name: Download APK
+          uses: actions/download-artifact@v4
+          with:
+            name: app-release
+
+        - name: Publicar Release
+          uses: softprops/action-gh-release@v2
+          with:
+            tag_name: v${{ github.run_number }}
+            name: "Release v${{ github.run_number }}"
+            files: app-release.apk
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adicionados os jobs build-android e create-release ao workflow.

O build-android configura o ambiente com Node.js 20 e JDK 17, gera o código nativo via expo prebuild, compila o APK com Gradle e salva como artefato.

O create-release baixa esse artefato e publica uma GitHub Release com o APK anexado, versionada automaticamente via run_number.